### PR TITLE
feat: Adjust container to run on OpenShift in rootless mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,11 @@ RUN --mount=type=tmpfs,target=/tmp bash /build/misp_compile_zlib_ng.sh
 # MISP image
 FROM base AS misp
 
+RUN groupadd -g 1001 misp && \
+    useradd -u 1001 -g 1001 -m -d /home/misp -s /bin/bash misp && \
+    # Add misp user to group 0 to have access to volumes
+    usermod -g 0 misp
+
 # Install required system and Python packages
 COPY requirements.txt packages /tmp/
 COPY bin/misp_enable_epel.sh bin/misp_enable_vector.sh /usr/local/bin/
@@ -41,22 +46,23 @@ RUN --mount=type=tmpfs,target=/var/cache/dnf \
     dnf module -y enable php:$PHP_VERSION && \
     dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y $(grep -vE "^\s*#" /tmp/packages | tr "\n" " ") && \
     pip3.12 --no-cache-dir install --disable-pip-version-check -r /tmp/requirements.txt && \
-    mkdir /run/php-fpm && \
+    mkdir -p /run/php-fpm /run/httpd && \
+    chown misp:misp /run/php-fpm /run/httpd && \
     rm -rf /tmp/packages
 
-COPY --from=builder --chmod=755 /usr/local/bin/su-exec /usr/local/bin/
-COPY --from=php-build /build/php-modules/* /usr/lib64/php/modules/
-COPY --from=jobber-build /build/jobber*.rpm /tmp
-COPY --from=zlib-ng-build /build/libz.so.1.3.1.zlib-ng /lib64/
-COPY --chmod=755 bin/ /usr/local/bin/
-COPY --chmod=644 misp.conf /etc/httpd/conf.d/misp.conf
-COPY --chmod=644 httpd-errors/* /var/www/html/
-COPY --chmod=644 vector.yaml /etc/vector/
-COPY --chmod=644 rsyslog.conf /etc/
-COPY --chmod=644 snuffleupagus-misp.rules /etc/php.d/
-COPY --chmod=644 .jobber /root/
-COPY --chmod=644 supervisor.ini /etc/supervisord.d/misp.ini
-COPY --chmod=644 logrotate/* /etc/logrotate.d/
+COPY --chown=misp:misp --from=builder --chmod=755 /usr/local/bin/su-exec /usr/local/bin/
+COPY --chown=misp:misp --from=php-build /build/php-modules/* /usr/lib64/php/modules/
+COPY --chown=misp:misp --from=jobber-build /build/jobber*.rpm /tmp
+COPY --chown=misp:misp --from=zlib-ng-build /build/libz.so.1.3.1.zlib-ng /lib64/
+COPY --chown=misp:misp --chmod=755 bin/ /usr/local/bin/
+COPY --chown=misp:misp --chmod=644 misp.conf /etc/httpd/conf.d/misp.conf
+COPY --chown=misp:misp --chmod=644 httpd-errors/* /var/www/html/
+COPY --chown=misp:misp --chmod=644 vector.yaml /etc/vector/
+COPY --chown=misp:misp --chmod=644 rsyslog.conf /etc/
+COPY --chown=misp:misp --chmod=644 snuffleupagus-misp.rules /etc/php.d/
+COPY --chown=misp:misp --chmod=644 .jobber /home/misp/
+COPY --chown=misp:misp --chmod=644 supervisor.ini /etc/supervisord.d/misp.ini
+COPY --chown=misp:misp --chmod=644 logrotate/* /etc/logrotate.d/
 
 ARG CACHEBUST=1
 ARG MISP_VERSION=2.5
@@ -64,17 +70,20 @@ ENV MISP_VERSION=$MISP_VERSION
 
 RUN ln -f -s /lib64/libz.so.1.3.1.zlib-ng /lib64/libz.so.1 && \
     rpm -i /tmp/jobber*.rpm && \
-    /usr/local/bin/misp_install.sh
-COPY --chmod=444 Config/* /var/www/MISP/app/Config/
-COPY --chmod=444 patches/cake.php /var/www/MISP/app/Console/
+    /usr/local/bin/misp_install.sh && \
+    update-crypto-policies
+COPY --chown=misp:misp --chmod=444 Config/* /var/www/MISP/app/Config/
+COPY --chown=misp:misp --chmod=444 patches/cake.php /var/www/MISP/app/Console/
 
 # Verify image
 FROM misp AS verify
 RUN touch /verified && \
     ln -s /usr/bin/python3.12 /usr/bin/python && \
-    su-exec apache /usr/local/bin/misp_verify.sh && \
+    su-exec misp /usr/local/bin/misp_verify.sh && \
     rm /usr/bin/python && \
-    /usr/bin/vector --config-dir /etc/vector/ validate
+    /usr/bin/vector --config-dir /etc/vector/ validate && \
+    httpd -t && \
+    php-fpm --test
 
 # Final image
 FROM misp
@@ -92,9 +101,10 @@ VOLUME /var/www/MISP/.gnupg/
 
 WORKDIR /var/www/MISP/
 # Web server
-EXPOSE 80
+EXPOSE 8080
 # ZeroMQ
 EXPOSE 50000
-HEALTHCHECK CMD su-exec apache misp_status.py
+USER misp
+HEALTHCHECK CMD misp_status.py
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["supervisord", "-c", "/etc/supervisord.conf"]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -39,9 +39,6 @@ file_env 'PROXY_PASSWORD'
 file_env 'ZEROMQ_USERNAME'
 file_env 'ZEROMQ_PASSWORD'
 
-# Change volumes permission to apache user
-chown apache:apache /var/www/MISP/app/{attachments,tmp/logs,files/certs,files/img/orgs,files/img/custom}
-
 if [ "$1" = 'supervisord' ]; then
     BUILD_DATE=$(cat /build-date)
     echo "======================================"
@@ -52,45 +49,32 @@ if [ "$1" = 'supervisord' ]; then
 
     misp_create_configs.py
 
-    update-crypto-policies
-
     # Create tmp directory for cake cache
     mkdir -p -m 770 /tmp/cake/
-    chown apache:apache /tmp/cake/
-
-    # Make config files not readable by others
-    chown root:apache /var/www/MISP/app/Config/{config.php,database.php,email.php}
-    chmod 440 /var/www/MISP/app/Config/{config.php,database.php,email.php}
 
     # Check syntax errors in generated config files
-    su-exec apache php -n -l /var/www/MISP/app/Config/config.php
-    su-exec apache php -n -l /var/www/MISP/app/Config/database.php
-    su-exec apache php -n -l /var/www/MISP/app/Config/email.php
+    php -n -l /var/www/MISP/app/Config/config.php
+    php -n -l /var/www/MISP/app/Config/database.php
+    php -n -l /var/www/MISP/app/Config/email.php
 
     # Create symlinks to images from customisation
-    su-exec apache misp_image_symlinks.py
+    misp_image_symlinks.py
 
     # Check if all permissions are OK
-    su-exec apache misp_check_permissions.py
-
-    # Check syntax of Apache2 configs
-    httpd -t
-
-    # Check syntax of PHP-FPM config
-    php-fpm --test
+    misp_check_permissions.py
 
     # Create database schema and check if database is ready
-    su-exec apache misp_create_database.py "$MYSQL_HOST" "$MYSQL_LOGIN" "$MYSQL_DATABASE" /var/www/MISP/INSTALL/MYSQL.sql
+    misp_create_database.py "$MYSQL_HOST" "$MYSQL_LOGIN" "$MYSQL_DATABASE" /var/www/MISP/INSTALL/MYSQL.sql
 
     # Check if redis is listening and running
-    su-exec apache misp_redis_ready.py
+    misp_redis_ready.py
 
     # Update database to latest version
-    su-exec apache /var/www/MISP/app/Console/cake Admin runUpdates || true
+    /var/www/MISP/app/Console/cake Admin runUpdates || true
 
     # Checks if encryption key is valid if set, but continue even if not valid
     if [[ -n $SECURITY_ENCRYPTION_KEY ]]; then
-      su-exec apache /var/www/MISP/app/Console/cake Admin isEncryptionKeyValid || true
+      /var/www/MISP/app/Console/cake Admin isEncryptionKeyValid || true
     fi
 
     # Precompress some CSS and JavaScript files by brotli
@@ -98,17 +82,15 @@ if [ "$1" = 'supervisord' ]; then
     brotli -f /var/www/MISP/app/webroot/js/{jquery,jquery-ui.min,chosen.jquery.min,bootstrap,bootstrap-datepicker,misp,vis}.js
 
     # Update all data stored in JSONs like objects, warninglists etc.
-    nice su-exec apache /var/www/MISP/app/Console/cake Admin updateJSON &
+    nice /var/www/MISP/app/Console/cake Admin updateJSON &
 fi
 
 # Create GPG homedir under apache user
-chown -R apache:apache /var/www/MISP/.gnupg
-chmod 700 /var/www/MISP/.gnupg
-su-exec apache gpg --homedir /var/www/MISP/.gnupg --list-keys
+gpg --homedir /var/www/MISP/.gnupg --list-keys
 
 if [ -n "${GNUPG_PRIVATE_KEY}" -a -n "${GNUPG_PRIVATE_KEY_PASSWORD}" ]; then
     # Import private key
-    su-exec apache gpg --homedir /var/www/MISP/.gnupg --import --batch \
+    gpg --homedir /var/www/MISP/.gnupg --import --batch \
         --passphrase "${GNUPG_PRIVATE_KEY_PASSWORD}" <<< "${GNUPG_PRIVATE_KEY}"
 fi
 

--- a/misp.conf
+++ b/misp.conf
@@ -28,8 +28,9 @@ ErrorLogFormat "%{cu}t;%-m;%l;%P;%T;%a;%L;%M"
 ErrorLog "|/usr/local/bin/su-exec apache /usr/local/bin/httpd_ecs_log.py error_log"
 {% endif %}
 
+Listen 8080
 # Specific VirthualHost bind to 127.0.0.2 for fetching metrics from server
-<VirtualHost 127.0.0.2:80>
+<VirtualHost 127.0.0.2:8080>
     # Disable access log for metrics
     CustomLog /dev/null combined
 
@@ -48,7 +49,7 @@ ErrorLog "|/usr/local/bin/su-exec apache /usr/local/bin/httpd_ecs_log.py error_l
     </Location>
 </VirtualHost>
 
-<VirtualHost *:80>
+<VirtualHost *:8080>
     DocumentRoot /var/www/MISP/app/webroot
 
     ErrorDocument 401 /401.html
@@ -86,7 +87,7 @@ ErrorLog "|/usr/local/bin/su-exec apache /usr/local/bin/httpd_ecs_log.py error_l
     RewriteEngine On
     {% if OIDC_LOGIN %}
     # Check if authkey is valid before we let apache to touch PHP
-    RewriteMap authkeys "prg:/var/www/MISP/app/Console/cake user authkey_valid --disableStdLog" apache:apache
+    RewriteMap authkeys "prg:/var/www/MISP/app/Console/cake user authkey_valid --disableStdLog" misp:misp
     {% endif %}
 
     <Directory /var/www/MISP/app/webroot>

--- a/supervisor.ini
+++ b/supervisor.ini
@@ -1,12 +1,12 @@
 [supervisord]
 nodaemon=true
-user=root
+user=misp
 
 # Allow apache user to access supervisor
 [unix_http_server]
 file=/run/supervisor/supervisor.sock
 chmod=0770
-chown=root:apache
+chown=misp:misp
 
 {% if SYSLOG_ENABLED %}
 [program:rsyslog]
@@ -34,7 +34,7 @@ command=/usr/local/libexec/jobbermaster
 {% if ZEROMQ_ENABLED %}
 [program:zeromq]
 command=misp_zeromq_start.sh
-user=apache
+user=misp
 {% endif %}
 
 [group:misp-workers]
@@ -48,7 +48,7 @@ numprocs={{ DEFAULT_WORKERS }}
 autorestart=true
 stderr_logfile=/var/www/MISP/app/tmp/logs/misp-workers-errors.log
 stdout_logfile=/var/www/MISP/app/tmp/logs/misp-workers.log
-user=apache
+user=misp
 environment=MISP_AUTOMATIC_TASK=true
 
 [program:email]
@@ -59,7 +59,7 @@ numprocs={{ EMAIL_WORKERS }}
 autorestart=true
 stderr_logfile=/var/www/MISP/app/tmp/logs/misp-workers-errors.log
 stdout_logfile=/var/www/MISP/app/tmp/logs/misp-workers.log
-user=apache
+user=misp
 environment=MISP_AUTOMATIC_TASK=true
 
 [program:cache]
@@ -70,7 +70,7 @@ numprocs={{ CACHE_WORKERS }}
 autorestart=true
 stderr_logfile=/var/www/MISP/app/tmp/logs/misp-workers-errors.log
 stdout_logfile=/var/www/MISP/app/tmp/logs/misp-workers.log
-user=apache
+user=misp
 environment=MISP_AUTOMATIC_TASK=true
 
 [program:prio]
@@ -81,7 +81,7 @@ numprocs={{ PRIO_WORKERS }}
 autorestart=true
 stderr_logfile=/var/www/MISP/app/tmp/logs/misp-workers-errors.log
 stdout_logfile=/var/www/MISP/app/tmp/logs/misp-workers.log
-user=apache
+user=misp
 environment=MISP_AUTOMATIC_TASK=true
 
 [program:update]
@@ -92,5 +92,5 @@ numprocs={{ UPDATE_WORKERS }}
 autorestart=true
 stderr_logfile=/var/www/MISP/app/tmp/logs/misp-workers-errors.log
 stdout_logfile=/var/www/MISP/app/tmp/logs/misp-workers.log
-user=apache
+user=misp
 environment=MISP_AUTOMATIC_TASK=true


### PR DESCRIPTION
This commit refactors the Docker container to run in a rootless mode, which is a requirement for environments like OpenShift.

The following changes were made:
- A dedicated non-root user `misp` with UID 1001 is created in the Dockerfile.
- File ownership and permissions are updated in the Dockerfile using `--chown` to avoid runtime `chown` commands.
- The application is configured to run on the non-privileged port 8080.
- The supervisor configuration is updated to run all processes as the `misp` user.
- The entrypoint script is refactored to remove all commands that require root privileges. These commands were moved to the Dockerfile build process.
- The `USER` instruction is added to the Dockerfile to switch to the `misp` user.